### PR TITLE
Add match.is type guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [Unreleased]
+
+### Added
+- Added `match(...).is()` chainable type-guard.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,0 @@
-# Changelog
-
-## [Unreleased]
-
-### Added
-- Added `match(...).is()` chainable type-guard.

--- a/README.md
+++ b/README.md
@@ -640,6 +640,20 @@ returns the result of the pattern-matching expression, or **throws** if no patte
 function run(): TOutput;
 ```
 
+### `.is`
+
+```ts
+if (match(value).is(P.string)) {
+  // `value` is inferred as string
+}
+```
+
+#### Signature
+
+```ts
+function is<const P extends Pattern<TInput>>(pattern: P): this is Pattern.infer<P>;
+```
+
 ### `isMatching`
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -643,23 +643,39 @@ function run(): TOutput;
 ### `.is`
 
 ```ts
-import { match, P } from 'ts-pattern';
-
-const value: unknown = 'hello';
-
-if (match(value).is(P.string)) {
-  // value: string
+if (match(value).is(pattern))  {
+  ...
 }
 ```
 
 `.is` is a chainable type guard method available on the object returned by `match(value)`.
-It returns `true` when the provided pattern matches the input and narrows the type of the input accordingly.
+It checks if a pattern matches the input value and narrows its type accordingly.
+
+```ts
+import { match, P } from 'ts-pattern';
+
+const blogPostPattern = {
+  type: 'blogpost',
+  title: P.string,
+  description: P.string,
+} as const;
+
+if (match(value).is(blogPostPattern)) {
+  // value: { type: 'blogpost', title: string, description: string }
+}
+```
 
 #### Signature
 
 ```ts
 function is<const P extends Pattern<TInput>>(pattern: P): this is Pattern.infer<P>;
 ```
+
+#### Arguments
+
+- `pattern: Pattern<TInput>`
+  - **Required**
+  - The pattern the input should match.
 
 ### `isMatching`
 

--- a/README.md
+++ b/README.md
@@ -643,10 +643,17 @@ function run(): TOutput;
 ### `.is`
 
 ```ts
+import { match, P } from 'ts-pattern';
+
+const value: unknown = 'hello';
+
 if (match(value).is(P.string)) {
-  // `value` is inferred as string
+  // value: string
 }
 ```
+
+`.is` is a chainable type guard method available on the object returned by `match(value)`.
+It returns `true` when the provided pattern matches the input and narrows the type of the input accordingly.
 
 #### Signature
 

--- a/src/match.ts
+++ b/src/match.ts
@@ -121,7 +121,7 @@ class MatchExpression<input, output> {
     return this.exhaustive();
   }
 
-  is<p extends Pattern<input>>(pattern: p): boolean {
+  is(pattern: Pattern<input>): boolean {
     return matchPattern(pattern, this.input, () => {});
   }
 

--- a/src/match.ts
+++ b/src/match.ts
@@ -121,6 +121,10 @@ class MatchExpression<input, output> {
     return this.exhaustive();
   }
 
+  is<p extends Pattern<input>>(pattern: p): boolean {
+    return matchPattern(pattern, this.input, () => {});
+  }
+
   returnType() {
     return this;
   }

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -1,5 +1,6 @@
 import type * as symbols from '../internals/symbols';
 import type { Pattern, MatchedValue } from './Pattern';
+import type * as P from '../patterns';
 import type { InvertPatternForExclude, InvertPattern } from './InvertPattern';
 import type { DeepExclude } from './DeepExclude';
 import type { Union, GuardValue, IsNever } from './helpers';
@@ -203,6 +204,12 @@ export type Match<
    * ⚠️ calling this function is unsafe, and may throw if no pattern matches your input.
    */
   run(): PickReturnValue<o, inferredOutput>;
+
+  /**
+   * `.is()` checks if the input matches a pattern. It can be chained after
+   * `match(value)` to perform type narrowing.
+   */
+  is<const p extends Pattern<i>>(pattern: p): this is MatchedValue<i, P.infer<p>>;
 
   /**
    * `.returnType<T>()` Lets you specify the return type for all of your branches.

--- a/tests/match-is.spec.ts
+++ b/tests/match-is.spec.ts
@@ -1,34 +1,120 @@
 import { match, P } from '../src';
-import { Expect, Equal } from '../src/types/helpers';
+import { Equal, Expect } from '../src/types/helpers';
 
 describe('match.is', () => {
-  it('works with primitive patterns', () => {
-    const value: unknown = 2;
-    expect(match(value).is(P.number)).toBe(true);
-    expect(match(value).is(P.string)).toBe(false);
+  it('works as a type guard with object patterns', () => {
+    const something: unknown = {
+      title: 'Hello',
+      author: { name: 'Gabriel', age: 27 },
+    };
 
-    if (match(value).is(P.number)) {
-      type t = Expect<Equal<typeof value, number>>;
+    if (
+      match(something).is({
+        title: P.string,
+        author: { name: P.string, age: P.number },
+      })
+    ) {
+      type t = Expect<
+        Equal<
+          typeof something,
+          { title: string; author: { name: string; age: number } }
+        >
+      >;
+      expect(true).toBe(true);
+    } else {
+      throw new Error('pattern should have matched');
     }
   });
 
   it('works with object patterns', () => {
-    const value: unknown = { foo: 'bar' };
-    expect(match(value).is({ foo: P.string })).toBe(true);
-    expect(match(value).is({ foo: P.number })).toBe(false);
-
-    if (match(value).is({ foo: P.string })) {
-      type t = Expect<Equal<typeof value, { foo: string }>>;
-    }
+    const value: unknown = { foo: true };
+    expect(match(value).is({ foo: true })).toEqual(true);
+    expect(match(value).is({ foo: 'true' })).toEqual(false);
   });
 
   it('works with array patterns', () => {
     const value: unknown = [1, 2, 3];
-    expect(match(value).is(P.array(P.number))).toBe(true);
-    expect(match(value).is(P.array(P.string))).toBe(false);
+    expect(match(value).is(P.array(P.number))).toEqual(true);
+    expect(match(value).is(P.array(P.string))).toEqual(false);
+  });
 
-    if (match(value).is(P.array(P.number))) {
-      type t = Expect<Equal<typeof value, number[]>>;
+  it('works with variadic patterns', () => {
+    const value: unknown = [1, 2, 3];
+    expect(match(value).is([1, ...P.array(P.number)])).toEqual(true);
+    expect(match(value).is([2, ...P.array(P.number)])).toEqual(false);
+  });
+
+  it('works with primitive patterns', () => {
+    const value: unknown = 1;
+    expect(match(value).is(P.number)).toEqual(true);
+    expect(match(value).is(P.boolean)).toEqual(false);
+  });
+
+  it('works with literal patterns', () => {
+    const value: unknown = 1;
+    expect(match(value).is(1)).toEqual(true);
+    expect(match(value).is('oops')).toEqual(false);
+  });
+
+  it('works with union and intersection patterns', () => {
+    const value: unknown = { foo: true };
+    expect(match(value).is(P.union({ foo: true }, { bar: false }))).toEqual(true);
+    expect(match(value).is(P.union({ foo: false }, { bar: false }))).toEqual(false);
+  });
+
+  type Pizza = { type: 'pizza'; topping: string };
+  type Sandwich = { type: 'sandwich'; condiments: string[] };
+  type Food = Pizza | Sandwich;
+
+  it('type inference should be precise without `as const`', () => {
+    const food = { type: 'pizza', topping: 'cheese' } as Food;
+
+    if (match(food).is({ type: 'pizza' })) {
+      type t = Expect<Equal<typeof food, Pizza>>;
+    } else {
+      throw new Error('Expected food to match the pizza pattern!');
+    }
+  });
+
+  it('should reject invalid pattern', () => {
+    const food = { type: 'pizza', topping: 'cheese' } as Food;
+
+    match(food).is(
+      // @ts-expect-error
+      {
+        type: 'oops',
+      }
+    );
+  });
+
+  it('should allow patterns targetting one member of a union type', () => {
+    const food = { type: 'pizza', topping: 'cheese' } as Food;
+    expect(match(food).is({ topping: 'cheese' })).toBe(true);
+
+    if (match(food).is({ topping: 'cheese' })) {
+      type t = Expect<Equal<typeof food, Pizza & { topping: 'cheese'; type: 'pizza' }>>;
+    }
+  });
+
+  it('should allow targetting unknown properties', () => {
+    const food = { type: 'pizza', topping: 'cheese' } as Food;
+
+    expect(match(food).is({ unknownProp: P.instanceOf(Error) })).toBe(false);
+
+    if (match(food).is({ unknownProp: P.instanceOf(Error) })) {
+      type t = Expect<Equal<typeof food, Food & { unknownProp: Error }>>;
+    }
+  });
+
+  it('should correctly narrow undiscriminated unions of objects.', () => {
+    type Input = { someProperty: string[] } | { this: 'is a string' };
+    const input = { someProperty: ['hello'] } satisfies Input as Input;
+
+    if (match(input).is({ someProperty: P.array() })) {
+      expect(input.someProperty).toEqual(['hello']);
+      type t = Expect<Equal<typeof input.someProperty, string[]>>;
+    } else {
+      throw new Error('pattern should match');
     }
   });
 });

--- a/tests/match-is.spec.ts
+++ b/tests/match-is.spec.ts
@@ -1,0 +1,34 @@
+import { match, P } from '../src';
+import { Expect, Equal } from '../src/types/helpers';
+
+describe('match.is', () => {
+  it('works with primitive patterns', () => {
+    const value: unknown = 2;
+    expect(match(value).is(P.number)).toBe(true);
+    expect(match(value).is(P.string)).toBe(false);
+
+    if (match(value).is(P.number)) {
+      type t = Expect<Equal<typeof value, number>>;
+    }
+  });
+
+  it('works with object patterns', () => {
+    const value: unknown = { foo: 'bar' };
+    expect(match(value).is({ foo: P.string })).toBe(true);
+    expect(match(value).is({ foo: P.number })).toBe(false);
+
+    if (match(value).is({ foo: P.string })) {
+      type t = Expect<Equal<typeof value, { foo: string }>>;
+    }
+  });
+
+  it('works with array patterns', () => {
+    const value: unknown = [1, 2, 3];
+    expect(match(value).is(P.array(P.number))).toBe(true);
+    expect(match(value).is(P.array(P.string))).toBe(false);
+
+    if (match(value).is(P.array(P.number))) {
+      type t = Expect<Equal<typeof value, number[]>>;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- implement `match(...).is()` to test patterns and narrow the input
- support the new method in `Match` type definitions
- document the `.is` method in README
- note the addition in `CHANGELOG`
- cover primitive, object and array patterns in new tests

## Testing
- `npm run check`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a1b7acc808321bae04d13ec720ed6