### PR TITLE
Add safe parser with mismatch errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Type-Level TypeScript takes you on a deep dive into the most advanced features o
   - [`.exhaustive`](#exhaustive)
   - [`.otherwise`](#otherwise)
   - [`isMatching`](#ismatching)
+  - [`createSafeParser`](#createsafeparser)
   - [Patterns](#patterns)
     - [Literals](#literals)
     - [Wildcards](#wildcards)
@@ -701,6 +702,33 @@ export function isMatching<p extends Pattern<any>>(
   - **Optional**
   - if a value is given as second argument, `isMatching` will return a boolean telling us whether the pattern matches the value or not.
   - if we only give the pattern to the function, `isMatching` will return another **type guard function** taking a value and returning a boolean which tells us whether the pattern matches the value or not.
+
+### `createSafeParser`
+
+```ts
+import { createSafeParser, P } from 'ts-pattern';
+
+const parseBlogPost = createSafeParser({
+  type: 'blogpost',
+  title: P.string,
+  description: P.string,
+});
+
+const res = parseBlogPost(value);
+// res:
+//   { success: true, data: { ... } }
+//   OR
+//   { success: false, error: { path: ['title'], expected: P.string, actual: 42 } }
+```
+
+`createSafeParser` returns a function validating data against a pattern. It either returns `{ success: true; data }` when the value matches, or `{ success: false; error }` with a `PatternMismatch` describing the first failing property.
+
+The `PatternMismatch` object contains:
+
+- `path`: an array indicating the property path of the mismatch (e.g. `['user', 'address', 'street']`).
+- `expected`: the pattern fragment expected at that path.
+- `actual`: the actual value found in the input.
+- `type`: either `'missing-property'` when a required property is absent or `'invalid-value'` when a value doesn’t conform to the pattern.
 
 ## Patterns
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -13,3 +13,11 @@ export class NonExhaustiveError extends Error {
     super(`Pattern matching error: no pattern matches value ${displayedValue}`);
   }
 }
+
+export interface PatternMismatch {
+  /** path to the failing property (e.g. ["user","address","street"]) */
+  path: (string | number | symbol)[];
+  expected: unknown;
+  actual: unknown;
+  type: 'missing-property' | 'invalid-value';
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,5 +2,6 @@ import * as Pattern from './patterns';
 
 export { match } from './match';
 export { isMatching } from './is-matching';
+export { createSafeParser } from './safe-parser';
 export { Pattern, Pattern as P };
 export { NonExhaustiveError } from './errors';

--- a/src/internals/helpers.ts
+++ b/src/internals/helpers.ts
@@ -32,7 +32,9 @@ const isOptionalPattern = (
 export const matchPattern = (
   pattern: any,
   value: any,
-  select: (key: string, value: unknown) => void
+  select: (key: string, value: unknown) => void,
+  onMismatch?: (error: import('../errors').PatternMismatch) => void,
+  path: (string | number | symbol)[] = []
 ): boolean => {
   if (isMatcher(pattern)) {
     const matcher = pattern[symbols.matcher]();
@@ -40,15 +42,43 @@ export const matchPattern = (
     if (matched && selections) {
       Object.keys(selections).forEach((key) => select(key, selections[key]));
     }
+    if (!matched && onMismatch) {
+      onMismatch({
+        path,
+        expected: pattern,
+        actual: value,
+        type: 'invalid-value',
+      });
+    }
     return matched;
   }
 
   if (isObject(pattern)) {
-    if (!isObject(value)) return false;
+    if (!isObject(value)) {
+      if (onMismatch) {
+        onMismatch({
+          path,
+          expected: pattern,
+          actual: value,
+          type: 'invalid-value',
+        });
+      }
+      return false;
+    }
 
     // Tuple pattern
     if (Array.isArray(pattern)) {
-      if (!Array.isArray(value)) return false;
+      if (!Array.isArray(value)) {
+        if (onMismatch) {
+          onMismatch({
+            path,
+            expected: pattern,
+            actual: value,
+            type: 'invalid-value',
+          });
+        }
+        return false;
+      }
       let startPatterns = [];
       let endPatterns = [];
       let variadicPatterns: AnyMatcher[] = [];
@@ -72,6 +102,14 @@ export const matchPattern = (
         }
 
         if (value.length < startPatterns.length + endPatterns.length) {
+          if (onMismatch) {
+            onMismatch({
+              path,
+              expected: pattern,
+              actual: value,
+              type: 'invalid-value',
+            });
+          }
           return false;
         }
 
@@ -85,35 +123,87 @@ export const matchPattern = (
 
         return (
           startPatterns.every((subPattern, i) =>
-            matchPattern(subPattern, startValues[i], select)
+            matchPattern(subPattern, startValues[i], select, onMismatch, [
+              ...path,
+              i,
+            ])
           ) &&
           endPatterns.every((subPattern, i) =>
-            matchPattern(subPattern, endValues[i], select)
+            matchPattern(
+              subPattern,
+              endValues[i],
+              select,
+              onMismatch,
+              [...path, value.length - endPatterns.length + i]
+            )
           ) &&
           (variadicPatterns.length === 0
             ? true
-            : matchPattern(variadicPatterns[0], middleValues, select))
+            : matchPattern(
+                variadicPatterns[0],
+                middleValues,
+                select,
+                onMismatch,
+                [...path, startPatterns.length]
+              ))
         );
       }
 
-      return pattern.length === value.length
-        ? pattern.every((subPattern, i) =>
-            matchPattern(subPattern, value[i], select)
-          )
-        : false;
+      if (pattern.length !== value.length) {
+        if (onMismatch) {
+          onMismatch({
+            path,
+            expected: pattern,
+            actual: value,
+            type: 'invalid-value',
+          });
+        }
+        return false;
+      }
+
+      return pattern.every((subPattern, i) =>
+        matchPattern(subPattern, value[i], select, onMismatch, [...path, i])
+      );
     }
 
     return Reflect.ownKeys(pattern).every((k): boolean => {
       const subPattern = pattern[k];
 
-      return (
-        (k in value || isOptionalPattern(subPattern)) &&
-        matchPattern(subPattern, value[k], select)
+      if (!(k in value)) {
+        if (!isOptionalPattern(subPattern)) {
+          if (onMismatch) {
+            onMismatch({
+              path: [...path, k],
+              expected: subPattern,
+              actual: undefined,
+              type: 'missing-property',
+            });
+          }
+          return false;
+        }
+        return true;
+      }
+
+      return matchPattern(
+        subPattern,
+        (value as any)[k],
+        select,
+        onMismatch,
+        [...path, k]
       );
     });
   }
 
-  return Object.is(value, pattern);
+  const matched = Object.is(value, pattern);
+  if (!matched && onMismatch) {
+    onMismatch({
+      path,
+      expected: pattern,
+      actual: value,
+      type: 'invalid-value',
+    });
+  }
+  return matched;
 };
 
 // @internal

--- a/src/safe-parser.ts
+++ b/src/safe-parser.ts
@@ -1,0 +1,15 @@
+import { matchPattern } from './internals/helpers';
+import type { Pattern } from './types/Pattern';
+import type { PatternMismatch } from './errors';
+
+export function createSafeParser<P extends Pattern<any>>(pattern: P) {
+  return (value: unknown) => {
+    let error: PatternMismatch | undefined;
+    const matched = matchPattern(pattern, value, () => {}, (e) => {
+      error = e;
+    });
+    return matched
+      ? { success: true as const, data: value as import('./patterns').infer<P> }
+      : { success: false as const, error: error! };
+  };
+}

--- a/tests/safe-parser.test.ts
+++ b/tests/safe-parser.test.ts
@@ -1,0 +1,16 @@
+import { createSafeParser, P } from '../src';
+
+describe('createSafeParser', () => {
+  it('should return success when value matches', () => {
+    const parse = createSafeParser({ type: 'blogpost', title: P.string });
+    const value = { type: 'blogpost', title: 'Hello' };
+    expect(parse(value)).toEqual({ success: true, data: value });
+  });
+
+  it('should return error with path to mismatch', () => {
+    const parse = createSafeParser({ user: { name: P.string } });
+    const result = parse({ user: { name: 42 } });
+    expect(result.success).toBe(false);
+    expect(result.error.path).toEqual(['user', 'name']);
+  });
+});


### PR DESCRIPTION
## Summary
- provide `PatternMismatch` interface and add mismatch reporting to `matchPattern`
- introduce `createSafeParser` helper and export from index
- add tests for `createSafeParser`
- document `createSafeParser` in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a53f8cd408321ba5ab76466a581cf