### PR TITLE
Add pattern guard to match expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Type-Level TypeScript takes you on a deep dive into the most advanced features o
   - [`.with`](#with)
   - [`.when`](#when)
   - [`.returnType`](#returntype)
+  - [`.is`](#is)
   - [`.exhaustive`](#exhaustive)
   - [`.otherwise`](#otherwise)
   - [`isMatching`](#ismatching)
@@ -535,6 +536,35 @@ function returnType<TOutputOverride>(): Match<TInput, TOutputOverride>;
 
 - `TOutputOverride`
   - The type that your `match` expression will return. All branches must return values assignable to it.
+
+### `.is`
+
+```ts
+const m = match(value);
+
+if (m.is(pattern)) {
+  // m.value is narrowed inside this block
+}
+
+const result = m.is(pattern, (v) => v); // returns handler output
+```
+
+`.is` acts as a type guard on the match expression. When the pattern matches, it
+narrows `m.value`. If a handler function is provided, its return value is
+returned when the pattern matches.
+
+#### Signature
+
+```ts
+function is<P extends PatternConstraint<TInput>>(pattern: P): this is Match<
+  TInput & WithDefault<P.narrow<TInput, P>, P.infer<P>>,
+  TOutput
+>;
+function is<P extends PatternConstraint<TInput>, R>(
+  pattern: P,
+  handler: (value: TInput & WithDefault<P.narrow<TInput, P>, P.infer<P>>) => R
+): R;
+```
 
 ### `.exhaustive`
 

--- a/src/is-matching.ts
+++ b/src/is-matching.ts
@@ -8,7 +8,7 @@ import { WithDefault } from './types/helpers';
  * in object patterns. See "should allow targetting unknown properties"
  * unit test in `is-matching.test.ts`.
  */
-type PatternConstraint<T> = T extends readonly any[]
+export type PatternConstraint<T> = T extends readonly any[]
   ? P.Pattern<T>
   : T extends object
   ? P.Pattern<T> & UnknownProperties

--- a/src/match.ts
+++ b/src/match.ts
@@ -3,6 +3,9 @@ import { Match } from './types/Match';
 import * as symbols from './internals/symbols';
 import { matchPattern } from './internals/helpers';
 import { NonExhaustiveError } from './errors';
+import { isMatching, PatternConstraint } from './is-matching';
+import * as P from './patterns';
+import { WithDefault } from './types/helpers';
 
 type MatchState<output> =
   | { matched: true; value: output }
@@ -46,6 +49,38 @@ export function match<const input, output = symbols.unset>(
  */
 class MatchExpression<input, output> {
   constructor(private input: input, private state: MatchState<output>) {}
+
+  get value(): input {
+    return this.input;
+  }
+
+  is<const pat extends PatternConstraint<input>>(pattern: pat): this is MatchExpression<
+    input & WithDefault<P.narrow<input, pat>, P.infer<pat>>,
+    output
+  >;
+  is<const pat extends PatternConstraint<input>, r>(
+    pattern: pat,
+    handler: (
+      value: input & WithDefault<P.narrow<input, pat>, P.infer<pat>>
+    ) => r
+  ): r;
+  is<const pat extends PatternConstraint<input>, r>(
+    pattern: pat,
+    handler?: (
+      value: input & WithDefault<P.narrow<input, pat>, P.infer<pat>>
+    ) => r
+  ): boolean | r {
+    const matches = isMatching(pattern, this.input);
+    if (handler) {
+      return matches
+        ? handler(
+            this.input as input &
+              WithDefault<P.narrow<input, pat>, P.infer<pat>>
+          )
+        : (undefined as unknown as r);
+    }
+    return matches;
+  }
 
   with(...args: any[]): MatchExpression<input, output> {
     if (this.state.matched) return this;

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -2,8 +2,9 @@ import type * as symbols from '../internals/symbols';
 import type { Pattern, MatchedValue } from './Pattern';
 import type { InvertPatternForExclude, InvertPattern } from './InvertPattern';
 import type { DeepExclude } from './DeepExclude';
-import type { Union, GuardValue, IsNever } from './helpers';
+import type { Union, GuardValue, IsNever, WithDefault } from './helpers';
 import type { FindSelected } from './FindSelected';
+import type { PatternConstraint } from '../is-matching';
 
 export type PickReturnValue<a, b> = a extends symbols.unset ? b : a;
 
@@ -25,6 +26,8 @@ export type Match<
   handledCases extends any[] = [],
   inferredOutput = never
 > = {
+  /** The input value being matched. */
+  readonly value: i;
   /**
    * `.with(pattern, handler)` Registers a pattern and an handler function that
    * will be called if the pattern matches the input value.
@@ -203,6 +206,23 @@ export type Match<
    * ⚠️ calling this function is unsafe, and may throw if no pattern matches your input.
    */
   run(): PickReturnValue<o, inferredOutput>;
+
+  /**
+   * `.is(pattern)` allows narrowing the current match expression with the given pattern.
+   * It acts as a type guard on the match expression instance.
+   */
+  is<const p extends PatternConstraint<i>>(pattern: p): this is Match<
+    i & WithDefault<p.narrow<i, p>, p.infer<p>>,
+    o,
+    handledCases,
+    inferredOutput
+  >;
+  is<const p extends PatternConstraint<i>, r>(
+    pattern: p,
+    handler: (
+      value: i & WithDefault<p.narrow<i, p>, p.infer<p>>
+    ) => r
+  ): r;
 
   /**
    * `.returnType<T>()` Lets you specify the return type for all of your branches.

--- a/tests/match-is.test.ts
+++ b/tests/match-is.test.ts
@@ -1,0 +1,40 @@
+import { match, P } from '../src';
+import { Expect, Equal } from '../src/types/helpers';
+
+describe('match.is', () => {
+  it('should narrow the value when used inside if', () => {
+    type Pizza = { type: 'pizza'; topping: string };
+    type Sandwich = { type: 'sandwich'; condiments: string[] };
+    const food: Pizza | Sandwich = { type: 'pizza', topping: 'cheese' } as Pizza | Sandwich;
+    const m = match(food);
+    if (m.is({ type: 'pizza' as const })) {
+      type t = Expect<Equal<typeof m.value, Pizza>>;
+    }
+  });
+
+  it('should return the handler result when pattern matches', () => {
+    type Pizza = { type: 'pizza'; topping: string };
+    type Sandwich = { type: 'sandwich'; condiments: string[] };
+    const food: Pizza | Sandwich = { type: 'pizza', topping: 'pepperoni' };
+
+    const m = match(food);
+    const topping = m.is({ type: 'pizza' as const }, (p) => {
+      type t = Expect<Equal<typeof p, Pizza>>;
+      return p.topping;
+    });
+
+    type t = Expect<Equal<typeof topping, string>>;
+    expect(topping).toBe('pepperoni');
+
+    const m2 = match<Pizza | Sandwich>({
+      type: 'sandwich',
+      condiments: ['mayo'],
+    });
+
+    const noTopping = m2.is({ type: 'pizza' as const }, (p) => p.topping);
+
+    type t2 = Expect<Equal<typeof noTopping, string>>;
+
+    expect(noTopping).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- expose `PatternConstraint` from `is-matching`
- allow retrieving the input value from `Match`
- add `is()` type guard method to match expressions
- support handler overload for `match.is`
- test narrowing with `match.is`
- document `.is()` in README
- clarify return behavior for handler overload
- refine return type of `.is` handler

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ade813bb88321b71c0639712992d1