### PR TITLE
Add `is` helper reversing `isMatching` args

### DIFF
--- a/README.md
+++ b/README.md
@@ -740,6 +740,26 @@ if (isStrict(value, { foo: P.number })) {
 }
 ```
 
+### `isStricter`
+
+```ts
+if (isStricter(value, pattern)) {
+  ...
+}
+```
+
+`isStricter` behaves like [`isStrict`](#isstrict) but will raise a type error if
+your pattern explicitly contains `undefined` for a property that is not
+optional in the value's type.
+
+```ts
+import { isStricter } from 'ts-pattern';
+
+declare const value: { foo: number };
+// @ts-expect-error - foo cannot be explicitly undefined
+isStricter(value, { foo: undefined });
+```
+
 ## Patterns
 
 A pattern is a description of the expected shape of your input value.

--- a/README.md
+++ b/README.md
@@ -721,6 +721,25 @@ if (is(value, { foo: P.number })) {
 }
 ```
 
+### `isStrict`
+
+```ts
+if (isStrict(value, pattern)) {
+  ...
+}
+```
+
+`isStrict` is similar to [`is`](#is) but only accepts patterns that are assignable to the value's type at compile time.
+
+```ts
+import { isStrict, P } from 'ts-pattern';
+
+const value = { foo: 2 } as const;
+if (isStrict(value, { foo: P.number })) {
+  // value: { foo: 2 }
+}
+```
+
 ## Patterns
 
 A pattern is a description of the expected shape of your input value.

--- a/README.md
+++ b/README.md
@@ -702,6 +702,25 @@ export function isMatching<p extends Pattern<any>>(
   - if a value is given as second argument, `isMatching` will return a boolean telling us whether the pattern matches the value or not.
   - if we only give the pattern to the function, `isMatching` will return another **type guard function** taking a value and returning a boolean which tells us whether the pattern matches the value or not.
 
+### `is`
+
+```ts
+if (is(value, pattern)) {
+  ...
+}
+```
+
+`is` works like [`isMatching`](#ismatching) but takes the value first and the pattern second.
+
+```ts
+import { is, P } from 'ts-pattern';
+
+const value = { foo: 2 };
+if (is(value, { foo: P.number })) {
+  // value: { foo: number }
+}
+```
+
 ## Patterns
 
 A pattern is a description of the expected shape of your input value.

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,5 +4,6 @@ export { match } from './match';
 export { isMatching } from './is-matching';
 export { is } from './is';
 export { isStrict } from './is-strict';
+export { isStricter } from './is-stricter';
 export { Pattern, Pattern as P };
 export { NonExhaustiveError } from './errors';

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,5 +2,6 @@ import * as Pattern from './patterns';
 
 export { match } from './match';
 export { isMatching } from './is-matching';
+export { is } from './is';
 export { Pattern, Pattern as P };
 export { NonExhaustiveError } from './errors';

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,5 +3,6 @@ import * as Pattern from './patterns';
 export { match } from './match';
 export { isMatching } from './is-matching';
 export { is } from './is';
+export { isStrict } from './is-strict';
 export { Pattern, Pattern as P };
 export { NonExhaustiveError } from './errors';

--- a/src/is-strict.ts
+++ b/src/is-strict.ts
@@ -1,0 +1,13 @@
+import * as Pattern from './patterns';
+import { match } from './match';
+
+/**
+ * `isStrict` takes a value and a pattern and checks if the value strictly matches the pattern.
+ * At the type level the pattern must be assignable to the value's type.
+ */
+export function isStrict<const T, const P extends Pattern.Pattern<T>>(
+  value: T,
+  pattern: P
+): value is Pattern.infer<P> {
+  return match(value).with(pattern, () => true).otherwise(() => false);
+}

--- a/src/is-strict.ts
+++ b/src/is-strict.ts
@@ -1,5 +1,5 @@
 import * as Pattern from './patterns';
-import { match } from './match';
+import { matchPattern } from './internals/helpers';
 
 /**
  * `isStrict` takes a value and a pattern and checks if the value strictly matches the pattern.
@@ -9,5 +9,5 @@ export function isStrict<const T, const P extends Pattern.Pattern<T>>(
   value: T,
   pattern: P
 ): value is Pattern.infer<P> {
-  return match(value).with(pattern, () => true).otherwise(() => false);
+  return matchPattern(pattern, value, () => {});
 }

--- a/src/is-stricter.ts
+++ b/src/is-stricter.ts
@@ -1,0 +1,28 @@
+import * as Pattern from './patterns';
+import { matchPattern } from './internals/helpers';
+import { Equal } from './types/helpers';
+
+// Utility type that collects keys where the pattern explicitly contains
+// `undefined` even though the value type does not.
+type BadUndefinedKeys<V, P> = {
+  [K in keyof P & keyof V]: Equal<P[K], undefined> extends true
+    ? (undefined extends V[K] ? never : K)
+    : P[K] extends object
+    ? BadUndefinedKeys<V[K], P[K]>
+    : never;
+}[keyof P & keyof V];
+
+// Reject patterns that explicitly use `undefined` where it is not allowed.
+type NoExplicitUndefined<V, P> = BadUndefinedKeys<V, P> extends never ? P : never;
+
+/**
+ * `isStricter` behaves like `isStrict` but additionally rejects patterns
+ * containing explicit `undefined` values for properties that are not
+ * optional in the value's type.
+ */
+export function isStricter<const T, const P extends Pattern.Pattern<T>>(
+  value: T,
+  pattern: NoExplicitUndefined<T, P>
+): value is Pattern.infer<P> {
+  return matchPattern(pattern, value, () => {});
+}

--- a/src/is.ts
+++ b/src/is.ts
@@ -1,0 +1,25 @@
+import { MatchedValue, Pattern, UnknownProperties } from './types/Pattern';
+import * as P from './patterns';
+import { matchPattern } from './internals/helpers';
+import { WithDefault } from './types/helpers';
+
+/**
+ * This constraint allows using additional properties
+ * in object patterns. See "should allow targetting unknown properties"
+ * unit test in `is-matching.test.ts`.
+ */
+type PatternConstraint<T> = T extends readonly any[]
+  ? P.Pattern<T>
+  : T extends object
+  ? P.Pattern<T> & UnknownProperties
+  : P.Pattern<T>;
+
+/**
+ * `is` takes a value and a pattern and checks if the value matches this pattern.
+ */
+export function is<const T, const P extends PatternConstraint<T>>(
+  value: T,
+  pattern: P
+): value is T & WithDefault<P.narrow<T, P>, P.infer<P>> {
+  return matchPattern(pattern, value, () => {});
+}

--- a/tests/is.test.ts
+++ b/tests/is.test.ts
@@ -1,0 +1,130 @@
+import { is, P } from '../src';
+import { Equal, Expect } from '../src/types/helpers';
+
+describe('is', () => {
+
+  it('should act as a type guard function if given a two arguments', () => {
+    const something: unknown = {
+      title: 'Hello',
+      author: { name: 'Gabriel', age: 27 },
+    };
+
+    if (
+      is(
+        something,
+        {
+          title: P.string,
+          author: { name: P.string, age: P.number },
+        }
+      )
+    ) {
+      type t = Expect<
+        Equal<
+          typeof something,
+          { title: string; author: { name: string; age: number } }
+        >
+      >;
+      expect(true).toBe(true);
+    } else {
+      throw new Error(
+        'is should have returned true but it returned false'
+      );
+    }
+  });
+
+  it('should work with object patterns', () => {
+    const value: unknown = { foo: true };
+    expect(is(value, { foo: true })).toEqual(true);
+    expect(is(value, { foo: 'true' })).toEqual(false);
+  });
+
+  it('should work with array patterns', () => {
+    const value: unknown = [1, 2, 3];
+    expect(is(value, P.array(P.number))).toEqual(true);
+    expect(is(value, P.array(P.string))).toEqual(false);
+  });
+
+  it('should work with variadic patterns', () => {
+    const value: unknown = [1, 2, 3];
+    expect(is(value, [1, ...P.array(P.number)])).toEqual(true);
+    expect(is(value, [2, ...P.array(P.number)])).toEqual(false);
+  });
+
+  it('should work with primitive patterns', () => {
+    const value: unknown = 1;
+    expect(is(value, P.number)).toEqual(true);
+    expect(is(value, P.boolean)).toEqual(false);
+  });
+
+  it('should work with literal patterns', () => {
+    const value: unknown = 1;
+    expect(is(value, 1)).toEqual(true);
+    expect(is(value, 'oops')).toEqual(false);
+  });
+
+  it('should work with union and intersection patterns', () => {
+    const value: unknown = { foo: true };
+    expect(is(value, P.union({ foo: true }, { bar: false }))).toEqual(true);
+
+    expect(is(value, P.union({ foo: false }, { bar: false }))).toEqual(false);
+  });
+
+  type Pizza = { type: 'pizza'; topping: string };
+  type Sandwich = { type: 'sandwich'; condiments: string[] };
+  type Food = Pizza | Sandwich;
+
+  it('type inference should be precise without `as const`', () => {
+    const food = { type: 'pizza', topping: 'cheese' } as Food;
+
+    if (is(food, { type: 'pizza' })) {
+      type t = Expect<Equal<typeof food, Pizza>>;
+    } else {
+      throw new Error('Expected food to match the pizza pattern!');
+    }
+  });
+
+  it('should reject invalid pattern when two parameters are passed', () => {
+    const food = { type: 'pizza', topping: 'cheese' } as Food;
+
+    is(
+      food,
+      // @ts-expect-error
+      {
+        type: 'oops',
+      }
+    );
+  });
+
+  it('should allow patterns targetting one member of a union type', () => {
+    const food = { type: 'pizza', topping: 'cheese' } as Food;
+    expect(is(food, { topping: 'cheese' })).toBe(true);
+
+    if (is(food, { topping: 'cheese' })) {
+      type t = Expect<
+        Equal<typeof food, Pizza & { topping: 'cheese'; type: 'pizza' }>
+      >;
+    }
+  });
+
+  it('should allow targetting unknown properties', () => {
+    const food = { type: 'pizza', topping: 'cheese' } as Food;
+
+    expect(is(food, { unknownProp: P.instanceOf(Error) })).toBe(false);
+
+    if (is(food, { unknownProp: P.instanceOf(Error) })) {
+      type t = Expect<Equal<typeof food, Food & { unknownProp: Error }>>;
+    }
+  });
+
+  it('should correctly narrow undiscriminated unions of objects.', () => {
+    type Input = { someProperty: string[] } | { this: 'is a string' };
+    const input = { someProperty: ['hello'] } satisfies Input as Input;
+
+    if (is(input, { someProperty: P.array() })) {
+      expect(input.someProperty).toEqual(['hello']);
+      type t = Expect<Equal<typeof input.someProperty, string[]>>;
+    } else {
+      throw new Error('pattern should match');
+    }
+  });
+});

--- a/tests/isStrict.test.ts
+++ b/tests/isStrict.test.ts
@@ -1,0 +1,127 @@
+import { isStrict as is, P } from '../src';
+import { Equal, Expect } from '../src/types/helpers';
+
+describe('isStrict', () => {
+
+  it('should act as a type guard function if given a two arguments', () => {
+    const something: unknown = {
+      title: 'Hello',
+      author: { name: 'Gabriel', age: 27 },
+    };
+
+    if (
+      is(
+        something,
+        {
+          title: P.string,
+          author: { name: P.string, age: P.number },
+        }
+      )
+    ) {
+      type t = Expect<
+        Equal<
+          typeof something,
+          { title: string; author: { name: string; age: number } }
+        >
+      >;
+      expect(true).toBe(true);
+    } else {
+      throw new Error(
+        'is should have returned true but it returned false'
+      );
+    }
+  });
+
+  it('should work with object patterns', () => {
+    const value: unknown = { foo: true };
+    expect(is(value, { foo: true })).toEqual(true);
+    expect(is(value, { foo: 'true' })).toEqual(false);
+  });
+
+  it('should work with array patterns', () => {
+    const value: unknown = [1, 2, 3];
+    expect(is(value, P.array(P.number))).toEqual(true);
+    expect(is(value, P.array(P.string))).toEqual(false);
+  });
+
+  it('should work with variadic patterns', () => {
+    const value: unknown = [1, 2, 3];
+    expect(is(value, [1, ...P.array(P.number)])).toEqual(true);
+    expect(is(value, [2, ...P.array(P.number)])).toEqual(false);
+  });
+
+  it('should work with primitive patterns', () => {
+    const value: unknown = 1;
+    expect(is(value, P.number)).toEqual(true);
+    expect(is(value, P.boolean)).toEqual(false);
+  });
+
+  it('should work with literal patterns', () => {
+    const value: unknown = 1;
+    expect(is(value, 1)).toEqual(true);
+    expect(is(value, 'oops')).toEqual(false);
+  });
+
+  it('should work with union and intersection patterns', () => {
+    const value: unknown = { foo: true };
+    expect(is(value, P.union({ foo: true }, { bar: false }))).toEqual(true);
+
+    expect(is(value, P.union({ foo: false }, { bar: false }))).toEqual(false);
+  });
+
+  type Pizza = { type: 'pizza'; topping: string };
+  type Sandwich = { type: 'sandwich'; condiments: string[] };
+  type Food = Pizza | Sandwich;
+
+  it('type inference should be precise without `as const`', () => {
+    const food = { type: 'pizza', topping: 'cheese' } as Food;
+
+    if (is(food, { type: 'pizza' })) {
+      type t = Expect<Equal<typeof food, Pizza>>;
+    } else {
+      throw new Error('Expected food to match the pizza pattern!');
+    }
+  });
+
+  it('should reject invalid pattern when two parameters are passed', () => {
+    const food = { type: 'pizza', topping: 'cheese' } as Food;
+
+    is(
+      food,
+      // @ts-expect-error
+      {
+        type: 'oops',
+      }
+    );
+  });
+
+  it('should allow patterns targetting one member of a union type', () => {
+    const food = { type: 'pizza', topping: 'cheese' } as Food;
+    expect(is(food, { topping: 'cheese' })).toBe(true);
+
+    if (is(food, { topping: 'cheese' })) {
+      type t = Expect<
+        Equal<typeof food, Pizza & { topping: 'cheese'; type: 'pizza' }>
+      >;
+    }
+  });
+
+  it('should reject patterns targetting unknown properties', () => {
+    const food = { type: 'pizza', topping: 'cheese' } as Food;
+
+    // @ts-expect-error - unknown properties are not allowed with isStrict
+    is(food, { unknownProp: P.instanceOf(Error) });
+  });
+
+  it('should correctly narrow undiscriminated unions of objects.', () => {
+    type Input = { someProperty: string[] } | { this: 'is a string' };
+    const input = { someProperty: ['hello'] } satisfies Input as Input;
+
+    if (is(input, { someProperty: P.array() })) {
+      expect(input.someProperty).toEqual(['hello']);
+      type t = Expect<Equal<typeof input.someProperty, string[]>>;
+    } else {
+      throw new Error('pattern should match');
+    }
+  });
+});

--- a/tests/isStricter.test.ts
+++ b/tests/isStricter.test.ts
@@ -1,0 +1,20 @@
+import { isStricter as is, P } from '../src';
+import { Expect, Equal } from '../src/types/helpers';
+
+describe('isStricter', () => {
+  type Pizza = { type: 'pizza'; topping: string };
+  type Sandwich = { type: 'sandwich'; condiments: string[] };
+  type Food = Pizza | Sandwich;
+
+  it('should reject explicit undefined for non optional property', () => {
+    const food = { type: 'pizza', topping: 'cheese' } as Food;
+    // @ts-expect-error - "type" cannot be explicitly undefined
+    is(food, { type: undefined });
+  });
+
+  it('should accept explicit undefined when allowed', () => {
+    type MaybeFood = { type?: 'pizza' };
+    const val: MaybeFood = {};
+    expect(is(val, { type: undefined })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add new `is` API which behaves like `isMatching` but takes the value first and pattern second
- document the new helper in README
- export `is` in the public API
- provide comprehensive tests for `is`
- remove currying support from the `is` helper

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f232b7148321bf9b774d20c8968a